### PR TITLE
docs: Blog post on How to Deploy Appsmith using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@
 20. [Creating a Delivery App in Appsmith](https://blog.greenflux.us/creating-a-delivery-app-in-appsmith) `appsmith`
 21. [Integrate Adalo with Appsmith](https://imknight.com/integrate-adalo-with-appsmith/) `blog`
 22. [Building a Cryptocurrency Price Tracker](https://dev.to/iamrosalp/build-a-cryptocurrency-price-tracker-appsmith-5fd9) `blog`
-23. [E-Commerce Store stock management Dashboard with MongoDB] (https://medium.com/@sanjiv12.8.2000/e-commerce-store-stock-management-dashboard-using-appsmith-and-mongodb-209c67ce14d6) `blog`
-
+23. [E-Commerce Store stock management Dashboard with MongoDB](https://medium.com/@sanjiv12.8.2000/e-commerce-store-stock-management-dashboard-using-appsmith-and-mongodb-209c67ce14d6) `blog`
+25. [How to Deploy Appsmith on private instance using Docker](https://dev.to/noviicee/how-to-deploy-appsmith-on-private-instance-using-docker-eig) `blog`
 
 `appsmith` - Appsmith Official
 


### PR DESCRIPTION
Added link for the appsmith tutorial from blog posted on Dev.to.
Find the issue [here](https://github.com/appsmithorg/appsmith-docs/issues/244#issuecomment-950545106)